### PR TITLE
Add ai-react app

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,8 @@
 node_modules
 .nx
 package-lock.json
+
+vite.config.*.timestamp*
+vitest.config.*.timestamp*
+
+ai-app/public/favicon.ico

--- a/.prettierignore
+++ b/.prettierignore
@@ -1,0 +1,5 @@
+# Add files here to ignore them from prettier formatting
+/dist
+/coverage
+/.nx/cache
+/.nx/workspace-data

--- a/.prettierrc
+++ b/.prettierrc
@@ -1,0 +1,3 @@
+{
+  "singleQuote": true
+}

--- a/.vscode/extensions.json
+++ b/.vscode/extensions.json
@@ -1,0 +1,3 @@
+{
+  "recommendations": ["ms-playwright.playwright"]
+}

--- a/README.md
+++ b/README.md
@@ -5,3 +5,9 @@ It has support for React, Angular, and Node projects written in TypeScript.
 ESLint, Prettier, and Jest come preconfigured. Nx Cloud is enabled for free caching.
 
 Use Nx commands to generate applications and libraries.
+
+## Applications
+
+### ai-app
+A simple React application with a single input field that can be used to trigger AI workflows.
+Run it with `npx nx serve ai-app` and open the browser to see the input form.

--- a/ai-app/index.html
+++ b/ai-app/index.html
@@ -1,0 +1,15 @@
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <meta charset="utf-8" />
+    <title>AiApp</title>
+    <base href="/" />
+
+    <meta name="viewport" content="width=device-width, initial-scale=1" />
+    <link rel="stylesheet" href="/src/styles.css" />
+  </head>
+  <body>
+    <div id="root"></div>
+    <script type="module" src="/src/main.tsx"></script>
+  </body>
+</html>

--- a/ai-app/project.json
+++ b/ai-app/project.json
@@ -1,0 +1,9 @@
+{
+  "name": "ai-app",
+  "$schema": "../node_modules/nx/schemas/project-schema.json",
+  "sourceRoot": "ai-app/src",
+  "projectType": "application",
+  "tags": [],
+  "// targets": "to see all targets run: nx show project ai-app --web",
+  "targets": {}
+}

--- a/ai-app/src/app/app.module.css
+++ b/ai-app/src/app/app.module.css
@@ -1,0 +1,1 @@
+/* Your styles goes here. */

--- a/ai-app/src/app/app.tsx
+++ b/ai-app/src/app/app.tsx
@@ -1,0 +1,30 @@
+import { useState } from 'react';
+
+export function App() {
+  const [prompt, setPrompt] = useState('');
+  const handleSubmit = (e: React.FormEvent) => {
+    e.preventDefault();
+    // TODO: trigger AI workflow with the prompt value
+    console.log('AI workflow triggered with:', prompt);
+  };
+
+  return (
+    <div style={{ padding: '2rem', fontFamily: 'sans-serif' }}>
+      <h1>AI Workflow Trigger</h1>
+      <form onSubmit={handleSubmit}>
+        <input
+          type="text"
+          value={prompt}
+          onChange={(e) => setPrompt(e.target.value)}
+          placeholder="Enter your prompt"
+          style={{ width: '300px', padding: '0.5rem' }}
+        />
+        <button type="submit" style={{ marginLeft: '1rem', padding: '0.5rem 1rem' }}>
+          Run
+        </button>
+      </form>
+    </div>
+  );
+}
+
+export default App;

--- a/ai-app/src/main.tsx
+++ b/ai-app/src/main.tsx
@@ -1,0 +1,13 @@
+import { StrictMode } from 'react';
+import * as ReactDOM from 'react-dom/client';
+import App from './app/app';
+
+const root = ReactDOM.createRoot(
+  document.getElementById('root') as HTMLElement
+);
+
+root.render(
+  <StrictMode>
+    <App />
+  </StrictMode>
+);

--- a/ai-app/src/styles.css
+++ b/ai-app/src/styles.css
@@ -1,0 +1,1 @@
+/* You can add global styles to this file, and also import other style files */

--- a/ai-app/tsconfig.app.json
+++ b/ai-app/tsconfig.app.json
@@ -1,0 +1,23 @@
+{
+  "extends": "./tsconfig.json",
+  "compilerOptions": {
+    "outDir": "../dist/out-tsc",
+    "types": [
+      "node",
+      "@nx/react/typings/cssmodule.d.ts",
+      "@nx/react/typings/image.d.ts",
+      "vite/client"
+    ]
+  },
+  "exclude": [
+    "src/**/*.spec.ts",
+    "src/**/*.test.ts",
+    "src/**/*.spec.tsx",
+    "src/**/*.test.tsx",
+    "src/**/*.spec.js",
+    "src/**/*.test.js",
+    "src/**/*.spec.jsx",
+    "src/**/*.test.jsx"
+  ],
+  "include": ["src/**/*.js", "src/**/*.jsx", "src/**/*.ts", "src/**/*.tsx"]
+}

--- a/ai-app/tsconfig.json
+++ b/ai-app/tsconfig.json
@@ -1,0 +1,18 @@
+{
+  "compilerOptions": {
+    "jsx": "react-jsx",
+    "allowJs": false,
+    "esModuleInterop": false,
+    "allowSyntheticDefaultImports": true,
+    "strict": true,
+    "types": ["vite/client"]
+  },
+  "files": [],
+  "include": [],
+  "references": [
+    {
+      "path": "./tsconfig.app.json"
+    }
+  ],
+  "extends": "../tsconfig.base.json"
+}

--- a/ai-app/vite.config.ts
+++ b/ai-app/vite.config.ts
@@ -1,0 +1,31 @@
+/// <reference types='vitest' />
+import { defineConfig } from 'vite';
+import react from '@vitejs/plugin-react';
+import { nxViteTsPaths } from '@nx/vite/plugins/nx-tsconfig-paths.plugin';
+import { nxCopyAssetsPlugin } from '@nx/vite/plugins/nx-copy-assets.plugin';
+
+export default defineConfig(() => ({
+  root: __dirname,
+  cacheDir: '../node_modules/.vite/ai-app',
+  server: {
+    port: 4200,
+    host: 'localhost',
+  },
+  preview: {
+    port: 4200,
+    host: 'localhost',
+  },
+  plugins: [react(), nxViteTsPaths(), nxCopyAssetsPlugin(['*.md'])],
+  // Uncomment this if you are using workers.
+  // worker: {
+  //  plugins: [ nxViteTsPaths() ],
+  // },
+  build: {
+    outDir: '../dist/ai-app',
+    emptyOutDir: true,
+    reportCompressedSize: true,
+    commonjsOptions: {
+      transformMixedEsModules: true,
+    },
+  },
+}));

--- a/nx.json
+++ b/nx.json
@@ -1,3 +1,53 @@
 {
-  "$schema": "./node_modules/nx/schemas/nx-schema.json"
+  "$schema": "./node_modules/nx/schemas/nx-schema.json",
+  "plugins": [
+    {
+      "plugin": "@nx/react/router-plugin",
+      "options": {
+        "buildTargetName": "build",
+        "devTargetName": "dev",
+        "startTargetName": "start",
+        "watchDepsTargetName": "watch-deps",
+        "buildDepsTargetName": "build-deps",
+        "typecheckTargetName": "typecheck"
+      }
+    },
+    {
+      "plugin": "@nx/vite/plugin",
+      "options": {
+        "buildTargetName": "build",
+        "testTargetName": "test",
+        "serveTargetName": "serve",
+        "devTargetName": "dev",
+        "previewTargetName": "preview",
+        "serveStaticTargetName": "serve-static",
+        "typecheckTargetName": "typecheck",
+        "buildDepsTargetName": "build-deps",
+        "watchDepsTargetName": "watch-deps"
+      }
+    },
+    {
+      "plugin": "@nx/playwright/plugin",
+      "options": {
+        "targetName": "e2e"
+      }
+    }
+  ],
+  "generators": {
+    "@nx/react": {
+      "application": {
+        "babel": true,
+        "style": "css",
+        "linter": "none",
+        "bundler": "vite"
+      },
+      "component": {
+        "style": "css"
+      },
+      "library": {
+        "style": "css",
+        "linter": "none"
+      }
+    }
+  }
 }

--- a/package.json
+++ b/package.json
@@ -18,9 +18,34 @@
   "homepage": "https://github.com/jessebuitenhuis/codexai#readme",
   "devDependencies": {
     "@nx/angular": "^21.2.0",
+    "@nx/devkit": "21.2.1",
+    "@nx/js": "21.2.1",
     "@nx/node": "^21.2.0",
-    "@nx/react": "^21.2.0",
-    "nx": "21.2.0"
+    "@nx/playwright": "21.2.1",
+    "@nx/react": "21.2.1",
+    "@nx/vite": "21.2.1",
+    "@nx/web": "21.2.1",
+    "@playwright/test": "^1.36.0",
+    "@swc-node/register": "~1.9.1",
+    "@swc/core": "~1.5.7",
+    "@swc/helpers": "~0.5.11",
+    "@types/node": "^20.0.0",
+    "@types/react": "19.0.0",
+    "@types/react-dom": "19.0.0",
+    "@vitejs/plugin-react": "^4.2.0",
+    "@vitest/ui": "^3.0.0",
+    "jiti": "2.4.2",
+    "jsdom": "~22.1.0",
+    "nx": "21.2.0",
+    "prettier": "^2.6.2",
+    "tslib": "^2.3.0",
+    "typescript": "~5.8.2",
+    "vite": "^6.0.0",
+    "vitest": "^3.0.0"
   },
-  "nx": {}
+  "nx": {},
+  "dependencies": {
+    "react": "19.0.0",
+    "react-dom": "19.0.0"
+  }
 }

--- a/tsconfig.base.json
+++ b/tsconfig.base.json
@@ -1,0 +1,20 @@
+{
+  "compileOnSave": false,
+  "compilerOptions": {
+    "rootDir": ".",
+    "sourceMap": true,
+    "declaration": false,
+    "moduleResolution": "node",
+    "emitDecoratorMetadata": true,
+    "experimentalDecorators": true,
+    "importHelpers": true,
+    "target": "es2015",
+    "module": "esnext",
+    "lib": ["es2020", "dom"],
+    "skipLibCheck": true,
+    "skipDefaultLibCheck": true,
+    "baseUrl": ".",
+    "paths": {}
+  },
+  "exclude": ["node_modules", "tmp"]
+}


### PR DESCRIPTION
## Summary
- initialize Nx React app called `ai-app`
- add simple input form to trigger AI workflows
- document the new app in README
- remove the binary favicon and ignore it

## Testing
- `npm test` *(fails: Error: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_6854685fd7f48324beb980945c53688b